### PR TITLE
Make the sort methods work with Python 3

### DIFF
--- a/python/sort.py
+++ b/python/sort.py
@@ -66,7 +66,7 @@ def mergeSort( lst ):
 
     return result
 
-  mid = len( lst ) / 2
+  mid = int(len( lst ) / 2)
   left, right = lst[:mid], lst[mid:]
   left = mergeSort( left )
   right = mergeSort( right )

--- a/python/sort.py
+++ b/python/sort.py
@@ -81,7 +81,7 @@ def quickSort( lst ):
     return lst
 
   # Naive pivot
-  pivot = lst.pop( len(lst) / 2 )
+  pivot = lst.pop( int(len(lst) / 2) )
   left = []
   right = []
   for l in lst:


### PR DESCRIPTION
The merge function of mergeSort breaks in Python 3 because of "new division". i.e. 3/2=1.5, which is no good as a list index. This PR fixes that by rounding the result down.

Same for quickSort.

@ksnavely 